### PR TITLE
Remove the 'register' keywork from hashCStringXorDJB

### DIFF
--- a/altrace_wx.cpp
+++ b/altrace_wx.cpp
@@ -62,7 +62,7 @@ void out_of_memory(void)
 static inline uint32 hashCStringXorDJB(const char *str)
 {
     size_t len = strlen(str);
-    register uint32 hash = 5381;
+    uint32 hash = 5381;
     while (len--)
         hash = ((hash << 5) + hash) ^ *(str++);
     return hash;


### PR DESCRIPTION
gcc complains about this as C++17 and later have removed/deprecated/etc it:
```
/home/david/Development/altrace/altrace_wx.cpp:65:21: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
```